### PR TITLE
[issue 42] - Adding the wildfly-target-distribution.jboss-eap-xp.merged-channel profile

### DIFF
--- a/application-provider/pom.xml
+++ b/application-provider/pom.xml
@@ -137,5 +137,11 @@
                 <excludedGroups.by-wildfly-target-distribution>wildfly,eap</excludedGroups.by-wildfly-target-distribution>
             </properties>
         </profile>
+        <profile>
+            <id>wildfly-target-distribution.jboss-eap-xp.merged-channel</id>
+            <properties>
+                <excludedGroups.by-wildfly-target-distribution>wildfly,eap</excludedGroups.by-wildfly-target-distribution>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/wildfly/README.md
+++ b/wildfly/README.md
@@ -14,6 +14,13 @@ JBoss EAP application, rather than a WildFly one, which is the default behavior.
 Adding `-Pwildfly-target-distribution.jboss-eap-xp` to the build will let Maven use the specifics for building a 
 JBoss EAP XP application, rather than a WildFly one, which is the default behavior.
 
+### `wildfly-target-distribution.jboss-eap-xp.merged-channel`
+
+Sometimes a single channel manifest can be used when building JBoss EAP XP applications, which is obtained by merging 
+the JBoss EAP and JBoss EAP XP requirements.
+Adding `-Pwildfly-target-distribution.jboss-eap-xp.merged-channel` allows provisioning JBoss EAP XP application out a 
+_merged_ channel manifest, as for example when testing JBoss EAP candidate releases (_CRs_).
+
 **IMPORTANT**:
 
 - When using `-Pwildfly-target-distribution.jboss-eap` the JBoss EAP 8.1 **Beta** GA bits coordinates will be used by 

--- a/wildfly/pom.xml
+++ b/wildfly/pom.xml
@@ -295,5 +295,80 @@
                 </pluginManagement>
             </build>
         </profile>
+        <profile>
+            <!--
+                When building applications for JBoss EAP XP candidate releases, a unique channel manifest is used,
+                which is obtained by merging the JBoss EAP and JBoss EAP XP requirements.
+                The following profile covers such use case, i.e. to allow testing JBoss EAP XP CRs.
+            -->
+            <id>wildfly-target-distribution.jboss-eap-xp.merged-channel</id>
+            <properties>
+                <wildfly-maven-plugin.groupId>org.jboss.eap.plugins</wildfly-maven-plugin.groupId>
+                <wildfly-maven-plugin.artifactId>eap-maven-plugin</wildfly-maven-plugin.artifactId>
+                <wildfly-maven-plugin.version>1.0.0.Final-redhat-00014</wildfly-maven-plugin.version>
+                <!-- Default JBoss EAP XP `microprofile` BOM version is set here and can be overridden for pulling the right BOM -->
+                <bom.wildfly-microprofile.groupId>org.jboss.bom</bom.wildfly-microprofile.groupId>
+                <bom.wildfly-microprofile.artifactId>jboss-eap-xp-microprofile</bom.wildfly-microprofile.artifactId>
+                <bom.wildfly-microprofile.version>5.0.2.GA-redhat-00003</bom.wildfly-microprofile.version>
+                <!-- FPLs -->
+                <wildfly.feature-pack.location>org.jboss.eap.xp:wildfly-galleon-pack:5.0.3.GA-redhat-00003</wildfly.feature-pack.location>
+                <wildfly.cloud-feature-pack.location>org.jboss.eap.cloud:eap-cloud-galleon-pack:1.0.0.Final-redhat-00008</wildfly.cloud-feature-pack.location>
+                <!-- JBoss EAP Channel coordinates -->
+                <wildfly.ee-channel.groupId>org.jboss.eap.channels</wildfly.ee-channel.groupId>
+                <wildfly.ee-channel.artifactId>custom-artifact-ID</wildfly.ee-channel.artifactId>
+                <wildfly.ee-channel.version>CUSTOM_VERSION</wildfly.ee-channel.version>
+            </properties>
+            <modules>
+                <module>microprofile-reactive-messaging-kafka</module>
+            </modules>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>${wildfly-maven-plugin.groupId}</groupId>
+                            <artifactId>${wildfly-maven-plugin.artifactId}</artifactId>
+                            <version>${wildfly-maven-plugin.version}</version>
+                            <configuration>
+                                <filename>ROOT.war</filename>
+                                <feature-packs>
+                                    <feature-pack>
+                                        <location>${wildfly.feature-pack.location}</location>
+                                    </feature-pack>
+                                    <feature-pack>
+                                        <location>${wildfly.cloud-feature-pack.location}</location>
+                                    </feature-pack>
+                                </feature-packs>
+                                <channels>
+                                    <channel>
+                                        <manifest>
+                                            <groupId>${wildfly.ee-channel.groupId}</groupId>
+                                            <artifactId>${wildfly.ee-channel.artifactId}</artifactId>
+                                            <version>${wildfly.ee-channel.version}</version>
+                                        </manifest>
+                                    </channel>
+                                </channels>
+                                <layers>
+                                    <layer>cloud-default-config</layer>
+                                </layers>
+                                <!--
+                                    Both the Bootable JAR and Maven plugin are executed on some cases and their executions
+                                    might collide. Let's isolate the WildFly/JBoss EAP Maven plugin execution to be safe
+                                -->
+                                <galleon-options>
+                                    <jboss-fork-embedded>true</jboss-fork-embedded>
+                                </galleon-options>
+                            </configuration>
+                            <executions>
+                                <execution>
+                                    <goals>
+                                        <goal>package</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
## Description

Adding the `wildfly-target-distribution.jboss-eap-xp.merged-channel` profile to provision JBoss EAP XP applications with a merged channel manifest

Resolves #42

**OpenShift validation checks**:
- :white_check_mark:  Internal job name: **eap-8.x-cross-product-openshift-jboss-eap-xp-openjdk21-kafka**, run: **26** - built with custom (CR) XP 6 bits, and a single channel manifest.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [x] I have implemented unit tests to cover my changes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/Intersmash/intersmash/tree/main/testsuite)
Please check integration tests and provide/improve tests if applicable.

Open your PR in Draft mode and verify all the applicable Checklist items before marking your pull request as ready for review
-->
